### PR TITLE
Installation typo in ReadMe

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,7 +11,7 @@ Closes with `Ctrl+W`, `Ctrl+Q`, or `Esc`. Arrow Keys select commits. `Tab` switc
 ```
 git clone https://github.com/Zren/gitz.git
 cd gitz
-chmox +x ./gitz.py
+chmod +x ./gitz.py
 sudo cp ./gitz.py /usr/local/bin/gitz
 ```
 


### PR DESCRIPTION
`chmox` -> `chmod`